### PR TITLE
README.md: don't mention RPC pattern and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The RabbitMQ Kotlin Coroutine Library is designed to provide Kotlin developers with an efficient, coroutine-based approach to interact with RabbitMQ.  
 This library simplifies message queue operations by integrating seamlessly with Kotlin's coroutines, offering a modern and reactive way to handle asynchronous messaging in Kotlin applications.   
-It supports a variety of advanced features including queue and exchange manipulations, message publishing with confirmation, message consuming with acknowledgment, transactional operations, and the Remote Procedure Call (RPC) pattern.  
+It supports a variety of advanced features including queue and exchange manipulations, message publishing with confirmation, message consuming with acknowledgment, and transactional operations.
 
 ## Features
 
@@ -12,7 +12,6 @@ It supports a variety of advanced features including queue and exchange manipula
 - **Message Publishing with Confirmation**: Publish messages to queues with the option to receive confirmations, ensuring reliable delivery and handling of messages.
 - **Message Consuming with Acknowledgment**: Consume messages from queues with acknowledgment support, allowing for precise control over message processing and acknowledging.
 - **Transactional Publishing and Consuming**: Support for transactional operations, enabling the grouping of publish and consume actions into atomic units, ensuring data consistency and reliability.
-- **RPC Pattern Implementation**: Facilitates the implementation of the RPC pattern, allowing for easy setup of request-response message flows, suitable for service-oriented architectures.
 
 ## Getting Started
 You need to have [Java 8](https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html) installed.
@@ -76,29 +75,6 @@ connection.txChannel {
         publish(message)
     }
 }
-```
-
-### RPC pattern
-```kotlin
-ConnectionFactory().apply { useNio() }.newConnection().use { conn ->
-        conn.channel {
-            logger.info { "Asking for greeting request..." }
-            val response = withTimeoutOrNull(1000) {
-                async(Dispatchers.IO) {
-                    rpc {
-                        val result = call(message)
-                        logger.info { "Got a message: ${String(result.body)}" }
-                        result
-                    }
-                }.await()
-            }
-            if (response == null) {
-                logger.info { "Timeout is exeeded" }
-            } else {
-                logger.info { "Result: ${String(response.body)}" }
-            }
-        }
-    }
 ```
 
 ## Links

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![CI](https://github.com/viartemev/rabbitmq-kotlin/actions/workflows/gradle.yml/badge.svg?branch=master)](https://github.com/viartemev/rabbitmq-kotlin/actions/workflows/gradle.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-The RabbitMQ Kotlin Coroutine Library is designed to provide Kotlin developers with an efficient, coroutine-based approach to interact with RabbitMQ.  
-This library simplifies message queue operations by integrating seamlessly with Kotlin's coroutines, offering a modern and reactive way to handle asynchronous messaging in Kotlin applications.   
+The RabbitMQ Kotlin Coroutine Library is designed to provide Kotlin developers with an efficient, coroutine-based approach to interact with RabbitMQ.
+This library simplifies message queue operations by integrating seamlessly with Kotlin's coroutines, offering a modern and reactive way to handle asynchronous messaging in Kotlin applications.
 It supports a variety of advanced features including queue and exchange manipulations, message publishing with confirmation, message consuming with acknowledgment, and transactional operations.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ dependencies {
 ```
 
 ## Examples
-Full list of examples could be found [here](https://github.com/viartemev/rabbitmq-kotlin/tree/master/rabbitmq-kotlin-example/src/main)
+Full list of examples could be found [here](rabbitmq-kotlin-example/src/main)
 
 ### Asynchronous message publishing with confirmation
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It supports a variety of advanced features including queue and exchange manipula
 - **RPC Pattern Implementation**: Facilitates the implementation of the RPC pattern, allowing for easy setup of request-response message flows, suitable for service-oriented architectures.
 
 ## Getting Started
-You need to have [Java 8](https://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
+You need to have [Java 8](https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html) installed.
 
 ### Snapshots
 ```gradle

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Full list of examples could be found [here](rabbitmq-kotlin-example/src/main)
         connection.confirmChannel {
             declareQueue(QueueSpecification(PUBLISHER_QUEUE_NAME)).queue
             publish {
-                (1..TIMES).map { createMessage("") }.map { async(Dispatchers.IO) { publishWithConfirm(it) } }.awaitAll()
+                (1..TIMES).map { createMessage("") }.map { publishWithConfirm(it) }
                     .forEach { println(it) }
             }
         }


### PR DESCRIPTION
- improve code in the example
- remove trailing spaces
- don't mention RPC pattern that isn't ready yet
- use a relative URL
- correct URL to Java 8 download page